### PR TITLE
[bugfix] MainScreenViewModel: (#8) lock buttons when exporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ visit, I would appreciate if you could take things easy when you see me doing so
 
 This App is fully functional.
 
-* 126 unit tests written as at 25 Aug 2022
-* More unit tests are being written to increase coverage and protect changes
+* 138 unit tests written as at 26 Aug 2022 to protect changes
 * Unit tests for composable functions (adding, but limited assertions available)
-* Dependency Injection: Koin
+* Dependency Injection: Koin (also considering Dagger 2)
 * Integrate SQLite (`SQLDelight`) as preferences store, and Google Maps Place API caches
-* Replace `java.io` calls with `kotlinx-io`
+* Considering okio as Java.io replacement
 
 ## Background
 

--- a/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
+++ b/src/jvmMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
@@ -223,19 +223,27 @@ class MainScreenViewModel(
     }
 
     fun setExportPlaceVisit(enabled: Boolean) {
-        _exportPlaceVisit.value = enabled
+        if (_mainScreenUIState.value is MainScreenUIState.Ready) {
+            _exportPlaceVisit.value = enabled
+        }
     }
 
     fun setExportActivitySegment(enabled: Boolean) {
-        _exportActivitySegment.value = enabled
+        if (_mainScreenUIState.value is MainScreenUIState.Ready) {
+            _exportActivitySegment.value = enabled
+        }
     }
 
     fun setEnablePlacesApiLookup(enabled: Boolean) {
-        _enablePlacesApiLookup.value = enabled
+        if (_mainScreenUIState.value is MainScreenUIState.Ready) {
+            _enablePlacesApiLookup.value = enabled
+        }
     }
 
     fun setVerboseLogs(enabled: Boolean) {
-        _verboseLogs.value = enabled
+        if (_mainScreenUIState.value is MainScreenUIState.Ready) {
+            _verboseLogs.value = enabled
+        }
     }
 
     fun onChangeJsonPath() {

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModelTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModelTest.kt
@@ -85,7 +85,7 @@ internal class MainScreenViewModelTest : FreeSpec() {
 
     init {
         "setExportPlaceVisit" - {
-            "should update exportPlaceVisit correctly" {
+            "should update exportPlaceVisit correctly when mainScreenUIState is Ready" {
                 // 🔴 Given
                 setupViewModel()
                 val initialState = mainScreenViewModel.exportPlaceVisit.first()
@@ -96,10 +96,49 @@ internal class MainScreenViewModelTest : FreeSpec() {
                 // 🟢 Then
                 mainScreenViewModel.exportPlaceVisit.first() shouldBe !initialState
             }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeICalPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeICalPath()
+                val initialState = mainScreenViewModel.exportPlaceVisit.first()
+
+                // 🟡 When
+                mainScreenViewModel.setExportPlaceVisit(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.exportPlaceVisit.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeJsonPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeJsonPath()
+                val initialState = mainScreenViewModel.exportPlaceVisit.first()
+
+                // 🟡 When
+                mainScreenViewModel.setExportPlaceVisit(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.exportPlaceVisit.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is Error" {
+                setupViewModel()
+                every { mockResourceBundle.getString("error.updating.json.path") } returns "some-error-string"
+                mainScreenViewModel.updateJsonPath(jFileChooserResult = JFileChooserResult.Error(errorCode = 521))
+                val initialState = mainScreenViewModel.exportPlaceVisit.first()
+
+                // 🟡 When
+                mainScreenViewModel.setExportPlaceVisit(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.exportPlaceVisit.first() shouldBe initialState
+            }
         }
 
         "setExportActivitySegment" - {
-            "should update exportActivitySegment correctly" {
+            "should update exportActivitySegment correctly when mainScreenUIState is Ready" {
                 // 🔴 Given
                 setupViewModel()
                 val initialState = mainScreenViewModel.exportActivitySegment.first()
@@ -110,10 +149,49 @@ internal class MainScreenViewModelTest : FreeSpec() {
                 // 🟢 Then
                 mainScreenViewModel.exportActivitySegment.first() shouldBe !initialState
             }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeICalPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeICalPath()
+                val initialState = mainScreenViewModel.exportActivitySegment.first()
+
+                // 🟡 When
+                mainScreenViewModel.setExportActivitySegment(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.exportActivitySegment.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeJsonPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeJsonPath()
+                val initialState = mainScreenViewModel.exportActivitySegment.first()
+
+                // 🟡 When
+                mainScreenViewModel.setExportActivitySegment(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.exportActivitySegment.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is Error" {
+                setupViewModel()
+                every { mockResourceBundle.getString("error.updating.json.path") } returns "some-error-string"
+                mainScreenViewModel.updateJsonPath(jFileChooserResult = JFileChooserResult.Error(errorCode = 521))
+                val initialState = mainScreenViewModel.exportActivitySegment.first()
+
+                // 🟡 When
+                mainScreenViewModel.setExportActivitySegment(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.exportActivitySegment.first() shouldBe initialState
+            }
         }
 
         "setEnablePlacesApiLookup" - {
-            "should update enablePlacesApiLookup correctly" {
+            "should update enablePlacesApiLookup correctly when mainScreenUIState is Ready" {
                 // 🔴 Given
                 setupViewModel()
                 val initialState = mainScreenViewModel.enablePlacesApiLookup.first()
@@ -124,10 +202,49 @@ internal class MainScreenViewModelTest : FreeSpec() {
                 // 🟢 Then
                 mainScreenViewModel.enablePlacesApiLookup.first() shouldBe !initialState
             }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeICalPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeICalPath()
+                val initialState = mainScreenViewModel.enablePlacesApiLookup.first()
+
+                // 🟡 When
+                mainScreenViewModel.setEnablePlacesApiLookup(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.enablePlacesApiLookup.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeJsonPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeJsonPath()
+                val initialState = mainScreenViewModel.enablePlacesApiLookup.first()
+
+                // 🟡 When
+                mainScreenViewModel.setEnablePlacesApiLookup(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.enablePlacesApiLookup.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is Error" {
+                setupViewModel()
+                every { mockResourceBundle.getString("error.updating.json.path") } returns "some-error-string"
+                mainScreenViewModel.updateJsonPath(jFileChooserResult = JFileChooserResult.Error(errorCode = 521))
+                val initialState = mainScreenViewModel.enablePlacesApiLookup.first()
+
+                // 🟡 When
+                mainScreenViewModel.setEnablePlacesApiLookup(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.enablePlacesApiLookup.first() shouldBe initialState
+            }
         }
 
         "setVerboseLogs" - {
-            "should update verboseLogs correctly" {
+            "should update verboseLogs correctly when mainScreenUIState is Ready" {
                 // 🔴 Given
                 setupViewModel()
                 val initialState = mainScreenViewModel.verboseLogs.first()
@@ -137,6 +254,45 @@ internal class MainScreenViewModelTest : FreeSpec() {
 
                 // 🟢 Then
                 mainScreenViewModel.verboseLogs.first() shouldBe !initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeICalPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeICalPath()
+                val initialState = mainScreenViewModel.verboseLogs.first()
+
+                // 🟡 When
+                mainScreenViewModel.setVerboseLogs(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.verboseLogs.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is ShowChangeJsonPathDialog" {
+                // 🔴 Given
+                setupViewModel()
+                mainScreenViewModel.onChangeJsonPath()
+                val initialState = mainScreenViewModel.verboseLogs.first()
+
+                // 🟡 When
+                mainScreenViewModel.setVerboseLogs(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.verboseLogs.first() shouldBe initialState
+            }
+
+            "should keep exportPlaceVisit unchanged when mainScreenUIState is Error" {
+                setupViewModel()
+                every { mockResourceBundle.getString("error.updating.json.path") } returns "some-error-string"
+                mainScreenViewModel.updateJsonPath(jFileChooserResult = JFileChooserResult.Error(errorCode = 521))
+                val initialState = mainScreenViewModel.verboseLogs.first()
+
+                // 🟡 When
+                mainScreenViewModel.setVerboseLogs(enabled = !initialState)
+
+                // 🟢 Then
+                mainScreenViewModel.verboseLogs.first() shouldBe initialState
             }
         }
 


### PR DESCRIPTION
This PR imposes UIState checking when the export options and advanced settings button are clicked. When the UIState is not ready, clicking these button will not alter their option state.