### PR TITLE
[test] improve unit tests readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ visit, I would appreciate if you could take things easy when you see me doing so
 
 This App is fully functional.
 
-* 170 unit tests written as at 30 Jan 2023 to protect changes
+* 169 unit tests written as at 1 Jan 2023 to protect changes
 * Unit tests for composable functions (adding, but limited assertions available)
 * Dependency Injection: Dagger 2
 * Integrate SQLite (`SQLDelight`) as preferences store, and Google Maps Place API caches

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/ActivitySegmentFormatterTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/ActivitySegmentFormatterTest.kt
@@ -16,7 +16,7 @@ internal class ActivitySegmentFormatterTest : FreeSpec() {
      */
     init {
         "parseActivityRouteText" - {
-            "should format string using startPlaceDetails if it is not null" {
+            "should format string using startPlaceDetails if it is not null and endPlaceDetails is null" {
                 // 🔴 Given
                 val startPlaceDetails = PlaceDetails(
                     placeId = "some-place-id",
@@ -45,7 +45,7 @@ internal class ActivitySegmentFormatterTest : FreeSpec() {
                 routeText shouldBe "(some-start-name ➡ null)"
             }
 
-            "should format string using endPlaceDetails if it is not null" {
+            "should format string using endPlaceDetails if it is not null and startPlaceDetails is null" {
                 // 🔴 Given
                 val startPlaceDetails = null
                 val endPlaceDetails = PlaceDetails(
@@ -111,35 +111,6 @@ internal class ActivitySegmentFormatterTest : FreeSpec() {
 
                 // 🟢 Then
                 routeText shouldBe "(some-start-name ➡ some-end-name)"
-            }
-
-            "should format string using startPlaceDetails if only that is not null" {
-                // 🔴 Given
-                val startPlaceDetails = PlaceDetails(
-                    placeId = "some-place-id",
-                    name = "some-start-name",
-                    formattedAddress = "some-formatted-address",
-                    geo = LatLng(
-                        latitude = 12.1234567,
-                        longitude = 123.1234567
-                    ),
-                    types = emptyList(),
-                    url = "https://some.url/"
-                )
-                val endPlaceDetails = null
-                val startLocation = "some-start-location"
-                val endLocation = "some-end-location"
-
-                // 🟡 When
-                val routeText = ActivitySegmentFormatter.parseActivityRouteText(
-                    startPlaceDetails = startPlaceDetails,
-                    endPlaceDetails = endPlaceDetails,
-                    startLocation = startLocation,
-                    endLocation = endLocation
-                )
-
-                // 🟢 Then - expecting null instead of empty string for manual editing
-                routeText shouldBe "(some-start-name ➡ null)"
             }
 
             "should format string using startLocation and endLocation if both PlaceDetails are null" {

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/VEventTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/VEventTest.kt
@@ -42,19 +42,7 @@ internal class VEventTest : FreeSpec() {
                     val lastPlaceDetails = mockActivityLastSegmentPlaceDetails
                     val startPlaceDetails = mockActivityStartSegmentPlaceDetails
                     val endPlaceDetails = mockActivityEndSegmentPlaceDetails
-
-                    // 🟡 When
-                    val vEvent = VEvent.from(
-                        activitySegment = activitySegment,
-                        shouldShowMiles = shouldShowMiles,
-                        firstPlaceDetails = firstPlaceDetails,
-                        lastPlaceDetails = lastPlaceDetails,
-                        startPlaceDetails = startPlaceDetails,
-                        endPlaceDetails = endPlaceDetails
-                    )
-
-                    // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = "some-end-location-place-id",
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -68,6 +56,19 @@ internal class VEventTest : FreeSpec() {
                         url = "https://www.google.com/maps/place/?q=place_id:some-end-location-place-id",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
+
+                    // 🟡 When
+                    val vEvent = VEvent.from(
+                        activitySegment = activitySegment,
+                        shouldShowMiles = shouldShowMiles,
+                        firstPlaceDetails = firstPlaceDetails,
+                        lastPlaceDetails = lastPlaceDetails,
+                        startPlaceDetails = startPlaceDetails,
+                        endPlaceDetails = endPlaceDetails
+                    )
+
+                    // 🟢 Then
+                    vEvent shouldBe expectedVEvent
                 }
 
                 "Should convert ActivitySegment with null endLocation.placeId to VEvent correctly" {
@@ -86,19 +87,7 @@ internal class VEventTest : FreeSpec() {
                     val lastPlaceDetails = mockActivityLastSegmentPlaceDetails
                     val startPlaceDetails = mockActivityStartSegmentPlaceDetails
                     val endPlaceDetails = mockActivityEndSegmentPlaceDetails
-
-                    // 🟡 When
-                    val vEvent = VEvent.from(
-                        activitySegment = activitySegment,
-                        shouldShowMiles = shouldShowMiles,
-                        firstPlaceDetails = firstPlaceDetails,
-                        lastPlaceDetails = lastPlaceDetails,
-                        startPlaceDetails = startPlaceDetails,
-                        endPlaceDetails = endPlaceDetails
-                    )
-
-                    // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = null,
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -112,16 +101,6 @@ internal class VEventTest : FreeSpec() {
                         url = "https://maps.google.com?q=26.33933,127.85",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
-                }
-
-                "Should convert kilometres to miles in VEvent if shouldShowMiles is true" {
-                    // 🔴 Given
-                    val activitySegment = mockActivitySegment
-                    val shouldShowMiles = true
-                    val firstPlaceDetails = mockActivityFirstSegmentPlaceDetails
-                    val lastPlaceDetails = mockActivityLastSegmentPlaceDetails
-                    val startPlaceDetails = mockActivityStartSegmentPlaceDetails
-                    val endPlaceDetails = mockActivityEndSegmentPlaceDetails
 
                     // 🟡 When
                     val vEvent = VEvent.from(
@@ -134,7 +113,18 @@ internal class VEventTest : FreeSpec() {
                     )
 
                     // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    vEvent shouldBe expectedVEvent
+                }
+
+                "Should convert kilometres to miles in VEvent if shouldShowMiles is true" {
+                    // 🔴 Given
+                    val activitySegment = mockActivitySegment
+                    val shouldShowMiles = true
+                    val firstPlaceDetails = mockActivityFirstSegmentPlaceDetails
+                    val lastPlaceDetails = mockActivityLastSegmentPlaceDetails
+                    val startPlaceDetails = mockActivityStartSegmentPlaceDetails
+                    val endPlaceDetails = mockActivityEndSegmentPlaceDetails
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = "some-end-location-place-id",
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -148,16 +138,6 @@ internal class VEventTest : FreeSpec() {
                         url = "https://www.google.com/maps/place/?q=place_id:some-end-location-place-id",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
-                }
-
-                "Should convert ActivitySegment without PlaceDetails to VEvent correctly" {
-                    // 🔴 Given
-                    val activitySegment = mockActivitySegment
-                    val shouldShowMiles = false
-                    val firstPlaceDetails = null
-                    val lastPlaceDetails = null
-                    val startPlaceDetails = null
-                    val endPlaceDetails = null
 
                     // 🟡 When
                     val vEvent = VEvent.from(
@@ -170,7 +150,18 @@ internal class VEventTest : FreeSpec() {
                     )
 
                     // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    vEvent shouldBe expectedVEvent
+                }
+
+                "Should convert ActivitySegment without PlaceDetails to VEvent correctly" {
+                    // 🔴 Given
+                    val activitySegment = mockActivitySegment
+                    val shouldShowMiles = false
+                    val firstPlaceDetails = null
+                    val lastPlaceDetails = null
+                    val startPlaceDetails = null
+                    val endPlaceDetails = null
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = "some-end-location-place-id",
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -184,6 +175,19 @@ internal class VEventTest : FreeSpec() {
                         url = "https://www.google.com/maps/place/?q=place_id:some-end-location-place-id",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
+
+                    // 🟡 When
+                    val vEvent = VEvent.from(
+                        activitySegment = activitySegment,
+                        shouldShowMiles = shouldShowMiles,
+                        firstPlaceDetails = firstPlaceDetails,
+                        lastPlaceDetails = lastPlaceDetails,
+                        startPlaceDetails = startPlaceDetails,
+                        endPlaceDetails = endPlaceDetails
+                    )
+
+                    // 🟢 Then
+                    vEvent shouldBe expectedVEvent
                 }
             }
 
@@ -192,12 +196,7 @@ internal class VEventTest : FreeSpec() {
                     // 🔴 Given
                     val placeVisit = mockPlaceVisit
                     val placeDetails = mockPlaceVisitPlaceDetails
-
-                    // 🟡 When
-                    val vEvent = VEvent.from(placeVisit = placeVisit, placeDetails = placeDetails)
-
-                    // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = "some-place-visit-place-id",
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -211,18 +210,19 @@ internal class VEventTest : FreeSpec() {
                         url = "https://maps.google.com/?cid=1021876599690425051",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
+
+                    // 🟡 When
+                    val vEvent = VEvent.from(placeVisit = placeVisit, placeDetails = placeDetails)
+
+                    // 🟢 Then
+                    vEvent shouldBe expectedVEvent
                 }
 
                 "Should convert PlaceVisit without PlaceDetails to VEvent correctly" {
                     // 🔴 Given
                     val placeVisit = mockPlaceVisit
                     val placeDetails = null
-
-                    // 🟡 When
-                    val vEvent = VEvent.from(placeVisit = placeVisit, placeDetails = placeDetails)
-
-                    // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = "some-place-visit-place-id",
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -236,6 +236,12 @@ internal class VEventTest : FreeSpec() {
                         url = "https://www.google.com/maps/place/?q=place_id:some-place-visit-place-id",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
+
+                    // 🟡 When
+                    val vEvent = VEvent.from(placeVisit = placeVisit, placeDetails = placeDetails)
+
+                    // 🟢 Then
+                    vEvent shouldBe expectedVEvent
                 }
             }
 
@@ -244,12 +250,7 @@ internal class VEventTest : FreeSpec() {
                     // 🔴 Given
                     val childVisit = mockChildVisit
                     val placeDetails = mockChildVisitPlaceDetails
-
-                    // 🟡 When
-                    val vEvent = VEvent.from(childVisit = childVisit, placeDetails = placeDetails)
-
-                    // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = "some-child-visit-place-id",
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -263,18 +264,19 @@ internal class VEventTest : FreeSpec() {
                         url = "https://maps.google.com/?cid=1021876599690425051",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
+
+                    // 🟡 When
+                    val vEvent = VEvent.from(childVisit = childVisit, placeDetails = placeDetails)
+
+                    // 🟢 Then
+                    vEvent shouldBe expectedVEvent
                 }
 
                 "Should convert ChildVisit without PlaceDetails to VEvent correctly" {
                     // 🔴 Given
                     val childVisit = mockChildVisit
                     val placeDetails = null
-
-                    // 🟡 When
-                    val vEvent = VEvent.from(childVisit = childVisit, placeDetails = placeDetails)
-
-                    // 🟢 Then
-                    vEvent shouldBe VEvent(
+                    val expectedVEvent = VEvent(
                         uid = "2011-11-11T11:22:22.222Z",
                         placeId = "some-child-visit-place-id",
                         dtStamp = "2011-11-11T11:22:22.222Z",
@@ -288,6 +290,12 @@ internal class VEventTest : FreeSpec() {
                         url = "https://www.google.com/maps/place/?q=place_id:some-child-visit-place-id",
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
+
+                    // 🟡 When
+                    val vEvent = VEvent.from(childVisit = childVisit, placeDetails = placeDetails)
+
+                    // 🟢 Then
+                    vEvent shouldBe expectedVEvent
                 }
             }
         }
@@ -309,12 +317,7 @@ internal class VEventTest : FreeSpec() {
                     url = "https://maps.google.com/?cid=1021876599690425051",
                     lastModified = "2011-11-11T11:22:22.222Z"
                 )
-
-                // 🟡 When
-                val iCalString = vEvent.export()
-
-                // 🟢 Then
-                iCalString shouldBe "BEGIN:VEVENT\n" +
+                val expectedICalString = "BEGIN:VEVENT\n" +
                     "TRANSP:OPAQUE\n" +
                     "DTSTART;TZID=Asia/Tokyo:20111112T051111\n" +
                     "DTEND;TZID=Asia/Tokyo:20111112T052222\n" +
@@ -332,6 +335,12 @@ internal class VEventTest : FreeSpec() {
                     "CREATED:2011-11-11T11:22:22.222Z\n" +
                     "X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC\n" +
                     "END:VEVENT\n"
+
+                // 🟡 When
+                val iCalString = vEvent.export()
+
+                // 🟢 Then
+                iCalString shouldBe expectedICalString
             }
         }
     }

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/LocationMapperTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/LocationMapperTest.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldBe
 class LocationMapperTest : FreeSpec() {
     init {
         "from Location Data Model" - {
-            "should convert locationDataModel to Location App Model correctly" - {
+            "should convert locationDataModel to Location Domain Model correctly" - {
                 // 🔴 Given
                 val locationDataModel = uk.ryanwong.gmap2ics.data.models.timeline.Location(
                     address = "some-address",
@@ -72,7 +72,7 @@ class LocationMapperTest : FreeSpec() {
         }
 
         "from ActivityLocation Data Model" - {
-            "should convert activityLocationDataModel to Location App Model correctly" - {
+            "should convert activityLocationDataModel to Location Domain Model correctly" - {
                 // 🔴 Given
                 val activityLocationDataModel = uk.ryanwong.gmap2ics.data.models.timeline.ActivityLocation(
                     address = "some-address",

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/PlaceDetailsTestData.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/PlaceDetailsTestData.kt
@@ -8,7 +8,7 @@ import uk.ryanwong.gmap2ics.data.models.places.Geometry
 import uk.ryanwong.gmap2ics.data.models.places.Location
 import uk.ryanwong.gmap2ics.data.models.places.Result
 
-object PlaceDetailsTestData {
+internal object PlaceDetailsTestData {
     /***
      * Note: Seeing real data would help understand what kind of data we are getting from Google.
      */

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/activity/ActivitySegmentMapperTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/activity/ActivitySegmentMapperTest.kt
@@ -19,6 +19,47 @@ internal class ActivitySegmentMapperTest : FreeSpec() {
 
     private lateinit var mockTimeZoneMap: MockTimeZoneMap
 
+    // Standard domain model as the baseline
+    // Tests only have to modify the necessary properties to highlight test focus
+    private val mockActivitySegmentDomainModel = ActivitySegment(
+        activities = listOf(
+            Activity(
+                activityType = ActivityType.IN_PASSENGER_VEHICLE,
+                rawActivityType = "IN_PASSENGER_VEHICLE"
+            ),
+            Activity(activityType = ActivityType.WALKING, rawActivityType = "WALKING"),
+            Activity(activityType = ActivityType.MOTORCYCLING, rawActivityType = "MOTORCYCLING")
+        ),
+        activityType = ActivityType.IN_PASSENGER_VEHICLE,
+        rawActivityType = "IN_PASSENGER_VEHICLE",
+        distance = 15032,
+        durationEndTimestamp = RawTimestamp(timestamp = "2019-06-01T01:24:28Z", timezoneId = "Asia/Tokyo"),
+        durationStartTimestamp = RawTimestamp(
+            timestamp = "2019-06-01T01:04:01Z",
+            timezoneId = "Asia/Tokyo"
+        ),
+        endLocation = Location(
+            placeId = null,
+            latitudeE7 = 344643393,
+            longitudeE7 = 1324226167,
+            name = null,
+            address = null
+        ),
+        startLocation = Location(
+            placeId = null,
+            latitudeE7 = 343970563,
+            longitudeE7 = 1324677422,
+            name = null,
+            address = null
+        ),
+        waypointPath = WaypointPath(
+            distanceMeters = 15444.856340505617,
+            roadSegmentPlaceIds = listOf("some-place-id-1", "some-place-id-2", "some-place-id-3")
+        ),
+        lastEditedTimestamp = "2019-06-01T01:24:28Z",
+        eventTimeZone = TimeZone(zoneId = "Asia/Tokyo", region = Polygon())
+    )
+
     init {
         "toDomainModel()" - {
             "should convert correctly from ActivitySegment Data Model to Domain Model" {
@@ -27,52 +68,16 @@ internal class ActivitySegmentMapperTest : FreeSpec() {
                 mockTimeZoneMap = MockTimeZoneMap().apply {
                     mockZoneId = "Asia/Tokyo"
                 }
+                val expectedDomainModel = mockActivitySegmentDomainModel
 
                 // 🟡 When
-                val activitySegment = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+                val activitySegmentDomainModel = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
 
                 // 🟢 Then
-                activitySegment shouldBe ActivitySegment(
-                    activities = listOf(
-                        Activity(
-                            activityType = ActivityType.IN_PASSENGER_VEHICLE,
-                            rawActivityType = "IN_PASSENGER_VEHICLE"
-                        ),
-                        Activity(activityType = ActivityType.WALKING, rawActivityType = "WALKING"),
-                        Activity(activityType = ActivityType.MOTORCYCLING, rawActivityType = "MOTORCYCLING")
-                    ),
-                    activityType = ActivityType.IN_PASSENGER_VEHICLE,
-                    rawActivityType = "IN_PASSENGER_VEHICLE",
-                    distance = 15032,
-                    durationEndTimestamp = RawTimestamp(timestamp = "2019-06-01T01:24:28Z", timezoneId = "Asia/Tokyo"),
-                    durationStartTimestamp = RawTimestamp(
-                        timestamp = "2019-06-01T01:04:01Z",
-                        timezoneId = "Asia/Tokyo"
-                    ),
-                    endLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 344643393,
-                        longitudeE7 = 1324226167,
-                        name = null,
-                        address = null
-                    ),
-                    startLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 343970563,
-                        longitudeE7 = 1324677422,
-                        name = null,
-                        address = null
-                    ),
-                    waypointPath = WaypointPath(
-                        distanceMeters = 15444.856340505617,
-                        roadSegmentPlaceIds = listOf("some-place-id-1", "some-place-id-2", "some-place-id-3")
-                    ),
-                    lastEditedTimestamp = "2019-06-01T01:24:28Z",
-                    eventTimeZone = TimeZone(zoneId = "Asia/Tokyo", region = Polygon())
-                )
+                activitySegmentDomainModel shouldBe expectedDomainModel
             }
 
-            "should still convert correctly from Data Model to Domain Model when ActivityType is null" {
+            "should still convert correctly from Data Model to Domain Model when rawActivityType is null" {
                 // 🔴 Given
                 val activitySegmentDataModel = mockActivitySegment.copy(
                     activityType = null
@@ -80,49 +85,16 @@ internal class ActivitySegmentMapperTest : FreeSpec() {
                 mockTimeZoneMap = MockTimeZoneMap().apply {
                     mockZoneId = "Asia/Tokyo"
                 }
-
-                // 🟡 When
-                val activitySegment = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
-
-                // 🟢 Then
-                activitySegment shouldBe ActivitySegment(
-                    activities = listOf(
-                        Activity(
-                            activityType = ActivityType.IN_PASSENGER_VEHICLE,
-                            rawActivityType = "IN_PASSENGER_VEHICLE"
-                        ),
-                        Activity(activityType = ActivityType.WALKING, rawActivityType = "WALKING"),
-                        Activity(activityType = ActivityType.MOTORCYCLING, rawActivityType = "MOTORCYCLING")
-                    ),
+                val expectedDomainModel = mockActivitySegmentDomainModel.copy(
                     activityType = ActivityType.UNKNOWN_ACTIVITY_TYPE,
                     rawActivityType = null,
-                    distance = 15032,
-                    durationEndTimestamp = RawTimestamp(timestamp = "2019-06-01T01:24:28Z", timezoneId = "Asia/Tokyo"),
-                    durationStartTimestamp = RawTimestamp(
-                        timestamp = "2019-06-01T01:04:01Z",
-                        timezoneId = "Asia/Tokyo"
-                    ),
-                    endLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 344643393,
-                        longitudeE7 = 1324226167,
-                        name = null,
-                        address = null
-                    ),
-                    startLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 343970563,
-                        longitudeE7 = 1324677422,
-                        name = null,
-                        address = null
-                    ),
-                    waypointPath = WaypointPath(
-                        distanceMeters = 15444.856340505617,
-                        roadSegmentPlaceIds = listOf("some-place-id-1", "some-place-id-2", "some-place-id-3")
-                    ),
-                    lastEditedTimestamp = "2019-06-01T01:24:28Z",
-                    eventTimeZone = TimeZone(zoneId = "Asia/Tokyo", region = Polygon())
                 )
+
+                // 🟡 When
+                val activitySegmentDomainModel = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+
+                // 🟢 Then
+                activitySegmentDomainModel shouldBe expectedDomainModel
             }
 
             "should still convert correctly from Data Model to Domain Model when activities is null" {
@@ -133,45 +105,18 @@ internal class ActivitySegmentMapperTest : FreeSpec() {
                 mockTimeZoneMap = MockTimeZoneMap().apply {
                     mockZoneId = "Asia/Tokyo"
                 }
+                val expectedDomainModel = mockActivitySegmentDomainModel.copy(
+                    activities = emptyList(),
+                )
 
                 // 🟡 When
-                val activitySegment = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+                val activitySegmentDomainModel = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
 
                 // 🟢 Then
-                activitySegment shouldBe ActivitySegment(
-                    activities = emptyList(),
-                    activityType = ActivityType.IN_PASSENGER_VEHICLE,
-                    rawActivityType = "IN_PASSENGER_VEHICLE",
-                    distance = 15032,
-                    durationEndTimestamp = RawTimestamp(timestamp = "2019-06-01T01:24:28Z", timezoneId = "Asia/Tokyo"),
-                    durationStartTimestamp = RawTimestamp(
-                        timestamp = "2019-06-01T01:04:01Z",
-                        timezoneId = "Asia/Tokyo"
-                    ),
-                    endLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 344643393,
-                        longitudeE7 = 1324226167,
-                        name = null,
-                        address = null
-                    ),
-                    startLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 343970563,
-                        longitudeE7 = 1324677422,
-                        name = null,
-                        address = null
-                    ),
-                    waypointPath = WaypointPath(
-                        distanceMeters = 15444.856340505617,
-                        roadSegmentPlaceIds = listOf("some-place-id-1", "some-place-id-2", "some-place-id-3")
-                    ),
-                    lastEditedTimestamp = "2019-06-01T01:24:28Z",
-                    eventTimeZone = TimeZone(zoneId = "Asia/Tokyo", region = Polygon())
-                )
+                activitySegmentDomainModel shouldBe expectedDomainModel
             }
 
-            "should still convert correctly from Data Model to Domain Model when ActivityType is not defined in the Enums" {
+            "should still convert correctly from Data Model to Domain Model when rawActivityType is not defined in the Enums" {
                 // 🔴 Given
                 val activitySegmentDataModel = mockActivitySegment.copy(
                     activityType = "some-strange-activity-type"
@@ -179,49 +124,16 @@ internal class ActivitySegmentMapperTest : FreeSpec() {
                 mockTimeZoneMap = MockTimeZoneMap().apply {
                     mockZoneId = "Asia/Tokyo"
                 }
-
-                // 🟡 When
-                val activitySegment = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
-
-                // 🟢 Then
-                activitySegment shouldBe ActivitySegment(
-                    activities = listOf(
-                        Activity(
-                            activityType = ActivityType.IN_PASSENGER_VEHICLE,
-                            rawActivityType = "IN_PASSENGER_VEHICLE"
-                        ),
-                        Activity(activityType = ActivityType.WALKING, rawActivityType = "WALKING"),
-                        Activity(activityType = ActivityType.MOTORCYCLING, rawActivityType = "MOTORCYCLING")
-                    ),
+                val expectedDomainModel = mockActivitySegmentDomainModel.copy(
                     activityType = ActivityType.UNKNOWN_ACTIVITY_TYPE,
                     rawActivityType = "some-strange-activity-type",
-                    distance = 15032,
-                    durationEndTimestamp = RawTimestamp(timestamp = "2019-06-01T01:24:28Z", timezoneId = "Asia/Tokyo"),
-                    durationStartTimestamp = RawTimestamp(
-                        timestamp = "2019-06-01T01:04:01Z",
-                        timezoneId = "Asia/Tokyo"
-                    ),
-                    endLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 344643393,
-                        longitudeE7 = 1324226167,
-                        name = null,
-                        address = null
-                    ),
-                    startLocation = Location(
-                        placeId = null,
-                        latitudeE7 = 343970563,
-                        longitudeE7 = 1324677422,
-                        name = null,
-                        address = null
-                    ),
-                    waypointPath = WaypointPath(
-                        distanceMeters = 15444.856340505617,
-                        roadSegmentPlaceIds = listOf("some-place-id-1", "some-place-id-2", "some-place-id-3")
-                    ),
-                    lastEditedTimestamp = "2019-06-01T01:24:28Z",
-                    eventTimeZone = TimeZone(zoneId = "Asia/Tokyo", region = Polygon())
                 )
+
+                // 🟡 When
+                val activitySegmentDomainModel = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+
+                // 🟢 Then
+                activitySegmentDomainModel shouldBe expectedDomainModel
             }
 
             "should return null if start location is null" {
@@ -234,10 +146,10 @@ internal class ActivitySegmentMapperTest : FreeSpec() {
                 }
 
                 // 🟡 When
-                val activitySegment = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+                val activitySegmentDomainModel = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
 
                 // 🟢 Then
-                activitySegment shouldBe null
+                activitySegmentDomainModel shouldBe null
             }
 
             "should return null if end location is null" {
@@ -250,10 +162,10 @@ internal class ActivitySegmentMapperTest : FreeSpec() {
                 }
 
                 // 🟡 When
-                val activitySegment = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+                val activitySegmentDomainModel = activitySegmentDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
 
                 // 🟢 Then
-                activitySegment shouldBe null
+                activitySegmentDomainModel shouldBe null
             }
         }
     }

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/placevisit/ChildVisitMapperTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/placevisit/ChildVisitMapperTest.kt
@@ -37,18 +37,13 @@ internal class ChildVisitMapperTest : FreeSpec() {
     )
 
     init {
-        "should correctly map Data Model to App Model" {
+        "should correctly map Data Model to Domain Model" {
             // 🔴 Given
             mockTimeZoneMap = MockTimeZoneMap().apply {
                 mockZoneId = "Europe/London"
             }
             val childVisitDataModel = mockChildVisit
-
-            // 🟡 When
-            val childVisitAppModel = childVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
-
-            // 🟢 Then
-            childVisitAppModel shouldBe ChildVisit(
+            val expectedDomainModel = ChildVisit(
                 durationEndTimestamp = RawTimestamp(timestamp = "2022-01-03T14:26:25Z", timezoneId = "Europe/London"),
                 durationStartTimestamp = RawTimestamp(timestamp = "2022-01-03T14:18:02Z", timezoneId = "Europe/London"),
                 lastEditedTimestamp = "2022-02-20T01:17:06.535Z",
@@ -61,9 +56,15 @@ internal class ChildVisitMapperTest : FreeSpec() {
                 ),
                 eventTimeZone = TimeZone(zoneId = "Europe/London", region = Polygon())
             )
+
+            // 🟡 When
+            val childVisitDomainModel = childVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+
+            // 🟢 Then
+            childVisitDomainModel shouldBe expectedDomainModel
         }
 
-        "should return null if App Model has no valid Location" {
+        "should return null if Domain Model has no valid Location" {
             // 🔴 Given
             mockTimeZoneMap = MockTimeZoneMap()
             val childVisitDataModel = mockChildVisit.copy(
@@ -71,13 +72,13 @@ internal class ChildVisitMapperTest : FreeSpec() {
             )
 
             // 🟡 When
-            val childVisitAppModel = childVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+            val childVisitDomainModel = childVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
 
             // 🟢 Then
-            childVisitAppModel shouldBe null
+            childVisitDomainModel shouldBe null
         }
 
-        "should return null if App Model has no valid Duration" {
+        "should return null if Domain Model has no valid Duration" {
             // 🔴 Given
             mockTimeZoneMap = MockTimeZoneMap()
             val childVisitDataModel = mockChildVisit.copy(
@@ -85,10 +86,10 @@ internal class ChildVisitMapperTest : FreeSpec() {
             )
 
             // 🟡 When
-            val childVisitAppModel = childVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+            val childVisitDomainModel = childVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
 
             // 🟢 Then
-            childVisitAppModel shouldBe null
+            childVisitDomainModel shouldBe null
         }
     }
 }

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/placevisit/PlaceVisitMapperTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/models/timeline/placevisit/PlaceVisitMapperTest.kt
@@ -18,18 +18,13 @@ internal class PlaceVisitMapperTest : FreeSpec() {
     private lateinit var mockTimeZoneMap: MockTimeZoneMap
 
     init {
-        "should correctly map Data Model to App Model" {
+        "should correctly map Data Model to Domain Model" {
             // 🔴 Given
             mockTimeZoneMap = MockTimeZoneMap().apply {
                 mockZoneId = "Europe/London"
             }
             val placeVisitDataModel = mockPlaceVisitDataModel
-
-            // 🟡 When
-            val placeVisitAppModel = placeVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
-
-            // 🟢 Then
-            placeVisitAppModel shouldBe PlaceVisit(
+            val expectedDomainModel = PlaceVisit(
                 durationEndTimestamp = RawTimestamp(
                     timestamp = "2022-01-03T14:26:25Z", timezoneId = "Europe/London"
                 ),
@@ -66,9 +61,15 @@ internal class PlaceVisitMapperTest : FreeSpec() {
                 ),
                 eventTimeZone = TimeZone(zoneId = "Europe/London", region = Polygon())
             )
+
+            // 🟡 When
+            val placeVisitDomainModel = placeVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+
+            // 🟢 Then
+            placeVisitDomainModel shouldBe expectedDomainModel
         }
 
-        "should still correctly map Data Model to App Model if no child visits" {
+        "should still correctly map Data Model to Domain Model if no child visits" {
             // 🔴 Given
             mockTimeZoneMap = MockTimeZoneMap().apply {
                 mockZoneId = "Europe/London"
@@ -76,12 +77,7 @@ internal class PlaceVisitMapperTest : FreeSpec() {
             val placeVisitDataModel = mockPlaceVisitDataModel.copy(
                 childVisits = null
             )
-
-            // 🟡 When
-            val placeVisitAppModel = placeVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
-
-            // 🟢 Then
-            placeVisitAppModel shouldBe PlaceVisit(
+            val expectedDomainModel = PlaceVisit(
                 durationEndTimestamp = RawTimestamp(
                     timestamp = "2022-01-03T14:26:25Z", timezoneId = "Europe/London"
                 ),
@@ -99,9 +95,15 @@ internal class PlaceVisitMapperTest : FreeSpec() {
                 childVisits = emptyList(),
                 eventTimeZone = TimeZone(zoneId = "Europe/London", region = Polygon())
             )
+
+            // 🟡 When
+            val placeVisitDomainModel = placeVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+
+            // 🟢 Then
+            placeVisitDomainModel shouldBe expectedDomainModel
         }
 
-        "should return null if App Model has no valid Location" {
+        "should return null if Domain Model has no valid Location" {
             // 🔴 Given
             mockTimeZoneMap = MockTimeZoneMap()
             val placeVisitDataModel = mockPlaceVisitDataModel.copy(
@@ -109,10 +111,10 @@ internal class PlaceVisitMapperTest : FreeSpec() {
             )
 
             // 🟡 When
-            val placeVisitAppModel = placeVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
+            val placeVisitDomainModel = placeVisitDataModel.toDomainModel(timeZoneMap = mockTimeZoneMap)
 
             // 🟢 Then
-            placeVisitAppModel shouldBe null
+            placeVisitDomainModel shouldBe null
         }
     }
 }

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/usecases/impl/VEventFromActivitySegmentUseCaseImplTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/usecases/impl/VEventFromActivitySegmentUseCaseImplTest.kt
@@ -58,15 +58,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromActivitySegmentUseCase(
-                activitySegment = activitySegment,
-                enablePlacesApiLookup = enablePlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-end-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -80,6 +72,15 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromActivitySegmentUseCase(
+                activitySegment = activitySegment,
+                enablePlacesApiLookup = enablePlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if activitySegment.eventTimeZone is null" {
@@ -99,15 +100,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromActivitySegmentUseCase(
-                activitySegment = activitySegment,
-                enablePlacesApiLookup = enablePlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-end-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -121,6 +114,15 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromActivitySegmentUseCase(
+                activitySegment = activitySegment,
+                enablePlacesApiLookup = enablePlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if enablePlacesApiLookup is false" {
@@ -138,15 +140,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromActivitySegmentUseCase(
-                activitySegment = activitySegment,
-                enablePlacesApiLookup = enablePlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-end-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -160,6 +154,15 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromActivitySegmentUseCase(
+                activitySegment = activitySegment,
+                enablePlacesApiLookup = enablePlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should still return correct VEvent if repository returns PlaceDetailsNotFoundException" {
@@ -169,15 +172,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
             val enablePlacesApiLookup = true
             mockPlaceDetailsRepository.getPlaceDetailsResponse =
                 Result.failure(exception = PlaceDetailsNotFoundException(placeId = "some-place-id"))
-
-            // 🟡 When
-            val vEvent = vEventFromActivitySegmentUseCase(
-                activitySegment = activitySegment,
-                enablePlacesApiLookup = enablePlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-end-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -191,6 +186,15 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromActivitySegmentUseCase(
+                activitySegment = activitySegment,
+                enablePlacesApiLookup = enablePlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should still return correct VEvent if repository returns GetPlaceDetailsAPIErrorException" {
@@ -200,15 +204,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
             val enablePlacesApiLookup = true
             mockPlaceDetailsRepository.getPlaceDetailsResponse =
                 Result.failure(exception = GetPlaceDetailsAPIErrorException(apiErrorMessage = "some-api-error-message"))
-
-            // 🟡 When
-            val vEvent = vEventFromActivitySegmentUseCase(
-                activitySegment = activitySegment,
-                enablePlacesApiLookup = enablePlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-end-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -222,6 +218,15 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromActivitySegmentUseCase(
+                activitySegment = activitySegment,
+                enablePlacesApiLookup = enablePlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         // Note: firstPlaceDetails and lastPlaceDetails are from the same list
@@ -242,6 +247,20 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                         url = "https://some.url/"
                     )
                 )
+                val expectedVEvent = VEvent(
+                    uid = "2011-11-11T11:22:22.222Z",
+                    placeId = "some-end-place-id",
+                    dtStamp = "2011-11-11T11:22:22.222Z",
+                    organizer = null,
+                    dtStart = RawTimestamp(timestamp = "2011-11-11T11:11:11.111Z", timezoneId = "Asia/Tokyo"),
+                    dtEnd = RawTimestamp(timestamp = "2011-11-11T11:22:22.222Z", timezoneId = "Asia/Tokyo"),
+                    summary = "✈️ 0.1km (some-place-name ➡ some-place-name)",
+                    location = "26.33933,127.85",
+                    geo = LatLng(latitude = 26.33933, longitude = 127.85),
+                    description = "Start Location: some-formatted-address\\nhttps://www.google.com/maps/place/?q=place_id:some-start-place-id\\n\\nEnd Location: some-formatted-address\\nhttps://www.google.com/maps/place/?q=place_id:some-end-place-id\\n\\n",
+                    url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
+                    lastModified = "2011-11-11T11:22:22.222Z"
+                )
 
                 // 🟡 When
                 val vEvent = vEventFromActivitySegmentUseCase(
@@ -250,21 +269,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                 )
 
                 // 🟢 Then
-                vEvent shouldBe
-                    VEvent(
-                        uid = "2011-11-11T11:22:22.222Z",
-                        placeId = "some-end-place-id",
-                        dtStamp = "2011-11-11T11:22:22.222Z",
-                        organizer = null,
-                        dtStart = RawTimestamp(timestamp = "2011-11-11T11:11:11.111Z", timezoneId = "Asia/Tokyo"),
-                        dtEnd = RawTimestamp(timestamp = "2011-11-11T11:22:22.222Z", timezoneId = "Asia/Tokyo"),
-                        summary = "✈️ 0.1km (some-place-name ➡ some-place-name)",
-                        location = "26.33933,127.85",
-                        geo = LatLng(latitude = 26.33933, longitude = 127.85),
-                        description = "Start Location: some-formatted-address\\nhttps://www.google.com/maps/place/?q=place_id:some-start-place-id\\n\\nEnd Location: some-formatted-address\\nhttps://www.google.com/maps/place/?q=place_id:some-end-place-id\\n\\n",
-                        url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
-                        lastModified = "2011-11-11T11:22:22.222Z"
-                    )
+                vEvent shouldBe expectedVEvent
             }
         }
 
@@ -284,15 +289,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                         url = "https://some.url/"
                     )
                 )
-
-                // 🟡 When
-                val vEvent = vEventFromActivitySegmentUseCase(
-                    activitySegment = activitySegment,
-                    enablePlacesApiLookup = enablePlacesApiLookup
-                )
-
-                // 🟢 Then
-                vEvent shouldBe VEvent(
+                val expectedVEvent = VEvent(
                     uid = "2011-11-11T11:22:22.222Z",
                     placeId = "some-end-place-id",
                     dtStamp = "2011-11-11T11:22:22.222Z",
@@ -306,6 +303,15 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                     url = "https://www.google.com/maps/place/?q=place_id:some-end-place-id",
                     lastModified = "2011-11-11T11:22:22.222Z"
                 )
+
+                // 🟡 When
+                val vEvent = vEventFromActivitySegmentUseCase(
+                    activitySegment = activitySegment,
+                    enablePlacesApiLookup = enablePlacesApiLookup
+                )
+
+                // 🟢 Then
+                vEvent shouldBe expectedVEvent
             }
         }
 
@@ -325,15 +331,7 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                         url = "https://some.url/"
                     )
                 )
-
-                // 🟡 When
-                val vEvent = vEventFromActivitySegmentUseCase(
-                    activitySegment = activitySegment,
-                    enablePlacesApiLookup = enablePlacesApiLookup
-                )
-
-                // 🟢 Then
-                vEvent shouldBe VEvent(
+                val expectedVEvent = VEvent(
                     uid = "2011-11-11T11:22:22.222Z",
                     placeId = null,
                     dtStamp = "2011-11-11T11:22:22.222Z",
@@ -347,6 +345,15 @@ internal class VEventFromActivitySegmentUseCaseImplTest : FreeSpec() {
                     url = "https://maps.google.com?q=26.33933,127.85",
                     lastModified = "2011-11-11T11:22:22.222Z"
                 )
+
+                // 🟡 When
+                val vEvent = vEventFromActivitySegmentUseCase(
+                    activitySegment = activitySegment,
+                    enablePlacesApiLookup = enablePlacesApiLookup
+                )
+
+                // 🟢 Then
+                vEvent shouldBe expectedVEvent
             }
         }
     }

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/usecases/impl/VEventFromChildVisitUseCaseImplTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/usecases/impl/VEventFromChildVisitUseCaseImplTest.kt
@@ -71,15 +71,7 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromChildVisitUseCase(
-                childVisit = childVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "place-id-to-be-kept",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -93,6 +85,15 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                 url = "https://some.url/",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromChildVisitUseCase(
+                childVisit = childVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if childVisit.location.placeId is null" {
@@ -114,15 +115,7 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromChildVisitUseCase(
-                childVisit = childVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = null,
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -136,6 +129,15 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:null",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromChildVisitUseCase(
+                childVisit = childVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if childVisit.eventTimeZone is null" {
@@ -155,15 +157,7 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromChildVisitUseCase(
-                childVisit = childVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "place-id-to-be-kept",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -177,6 +171,15 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                 url = "https://some.url/",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromChildVisitUseCase(
+                childVisit = childVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if enabledPlacesApiLookup is false" {
@@ -194,15 +197,7 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromChildVisitUseCase(
-                childVisit = childVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "place-id-to-be-kept",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -216,6 +211,15 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                 url = "https://some.url/",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromChildVisitUseCase(
+                childVisit = childVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should still return correct VEvent if repository returns PlaceDetailsNotFoundException" {
@@ -225,15 +229,7 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
             val enabledPlacesApiLookup = true
             mockPlaceDetailsRepository.getPlaceDetailsResponse =
                 Result.failure(exception = PlaceDetailsNotFoundException(placeId = "some-place-id"))
-
-            // 🟡 When
-            val vEvent = vEventFromChildVisitUseCase(
-                childVisit = childVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "place-id-to-be-kept",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -247,6 +243,15 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:place-id-to-be-kept",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromChildVisitUseCase(
+                childVisit = childVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should still return correct VEvent if repository returns GetPlaceDetailsAPIErrorException" {
@@ -256,15 +261,7 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
             val enabledPlacesApiLookup = true
             mockPlaceDetailsRepository.getPlaceDetailsResponse =
                 Result.failure(exception = GetPlaceDetailsAPIErrorException(apiErrorMessage = "some-api-error-message"))
-
-            // 🟡 When
-            val vEvent = vEventFromChildVisitUseCase(
-                childVisit = childVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "place-id-to-be-kept",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -278,6 +275,15 @@ internal class VEventFromChildVisitUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:place-id-to-be-kept",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromChildVisitUseCase(
+                childVisit = childVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
     }
 }

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/usecases/impl/VEventFromPlaceVisitUseCaseImplTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/app/usecases/impl/VEventFromPlaceVisitUseCaseImplTest.kt
@@ -74,15 +74,7 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromPlaceVisitUseCase(
-                placeVisit = placeVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -96,9 +88,19 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                 url = "https://some.url/",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromPlaceVisitUseCase(
+                placeVisit = placeVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if placeVisit.location.placeId is null" {
+            // Note: This is less-than-ideal case and not likely to happen, but we still have to return something to followup manually
             // 🔴 Given
             setupUseCase()
             val placeVisit = mockPlaceVisit.copy(
@@ -117,16 +119,7 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromPlaceVisitUseCase(
-                placeVisit = placeVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            // Note: This is less-than-ideal case and not likely to happen, but we still have to return something to followup manually
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = null,
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -140,6 +133,15 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:null",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromPlaceVisitUseCase(
+                placeVisit = placeVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if placeVisit.eventTimeZone is null" {
@@ -159,15 +161,7 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromPlaceVisitUseCase(
-                placeVisit = placeVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -181,6 +175,15 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                 url = "https://some.url/",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromPlaceVisitUseCase(
+                placeVisit = placeVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should return correct VEvent if enabledPlacesApiLookup is false" {
@@ -198,15 +201,7 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                     url = "https://some.url/"
                 )
             )
-
-            // 🟡 When
-            val vEvent = vEventFromPlaceVisitUseCase(
-                placeVisit = placeVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -220,6 +215,15 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                 url = "https://some.url/",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromPlaceVisitUseCase(
+                placeVisit = placeVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should still return correct VEvent if repository returns PlaceDetailsNotFoundException" {
@@ -229,15 +233,7 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
             val enabledPlacesApiLookup = true
             mockPlaceDetailsRepository.getPlaceDetailsResponse =
                 Result.failure(exception = PlaceDetailsNotFoundException(placeId = "some-place-id"))
-
-            // 🟡 When
-            val vEvent = vEventFromPlaceVisitUseCase(
-                placeVisit = placeVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -251,6 +247,15 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:some-place-id",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromPlaceVisitUseCase(
+                placeVisit = placeVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
 
         "should still return correct VEvent if repository returns GetPlaceDetailsAPIErrorException" {
@@ -260,15 +265,7 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
             val enabledPlacesApiLookup = true
             mockPlaceDetailsRepository.getPlaceDetailsResponse =
                 Result.failure(exception = GetPlaceDetailsAPIErrorException(apiErrorMessage = "some-api-error-message"))
-
-            // 🟡 When
-            val vEvent = vEventFromPlaceVisitUseCase(
-                placeVisit = placeVisit,
-                enablePlacesApiLookup = enabledPlacesApiLookup
-            )
-
-            // 🟢 Then
-            vEvent shouldBe VEvent(
+            val expectedVEvent = VEvent(
                 uid = "2011-11-11T11:22:22.222Z",
                 placeId = "some-place-id",
                 dtStamp = "2011-11-11T11:22:22.222Z",
@@ -282,6 +279,15 @@ internal class VEventFromPlaceVisitUseCaseImplTest : FreeSpec() {
                 url = "https://www.google.com/maps/place/?q=place_id:some-place-id",
                 lastModified = "2011-11-11T11:22:22.222Z"
             )
+
+            // 🟡 When
+            val vEvent = vEventFromPlaceVisitUseCase(
+                placeVisit = placeVisit,
+                enablePlacesApiLookup = enabledPlacesApiLookup
+            )
+
+            // 🟢 Then
+            vEvent shouldBe expectedVEvent
         }
     }
 }

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/PlaceVisitDataModelTestData.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/PlaceVisitDataModelTestData.kt
@@ -4,7 +4,7 @@
 
 package uk.ryanwong.gmap2ics.data.models.timeline
 
-object PlaceVisitDataModelTestData {
+internal object PlaceVisitDataModelTestData {
     val mockPlaceVisitDataModel = PlaceVisit(
         centerLatE7 = null,
         centerLngE7 = null,

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/repository/impl/LocalFileRepositoryImplTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/repository/impl/LocalFileRepositoryImplTest.kt
@@ -104,17 +104,7 @@ internal class LocalFileRepositoryImplTest : FreeSpec() {
                         lastModified = "2011-11-11T11:22:22.222Z"
                     )
                 )
-
-                // 🟡 When
-                val exportICalResponse = localFileRepository.exportICal(
-                    filename = "some-file-name",
-                    vEvents = vEventList
-                )
-
-                // 🟢 Then
-                exportICalResponse.isSuccess shouldBe true
-                localDataSource.fileWriterFileName shouldBe "some-file-name"
-                localDataSource.fileWriterContents shouldBe "BEGIN:VCALENDAR\n" +
+                val expectedFileContents = "BEGIN:VCALENDAR\n" +
                     "VERSION:2.0\n" +
                     "BEGIN:VEVENT\n" +
                     "TRANSP:OPAQUE\n" +
@@ -153,6 +143,17 @@ internal class LocalFileRepositoryImplTest : FreeSpec() {
                     "X-APPLE-TRAVEL-ADVISORY-BEHAVIOR:AUTOMATIC\n" +
                     "END:VEVENT\n" +
                     "END:VCALENDAR\n"
+
+                // 🟡 When
+                val exportICalResponse = localFileRepository.exportICal(
+                    filename = "some-file-name",
+                    vEvents = vEventList
+                )
+
+                // 🟢 Then
+                exportICalResponse.isSuccess shouldBe true
+                localDataSource.fileWriterFileName shouldBe "some-file-name"
+                localDataSource.fileWriterContents shouldBe expectedFileContents
             }
 
             "should return Result.failure if data source return error" {

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/repository/impl/TimelineRepositoryImplTestData.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/repository/impl/TimelineRepositoryImplTestData.kt
@@ -16,7 +16,7 @@ import uk.ryanwong.gmap2ics.app.models.timeline.activity.WaypointPath
 import uk.ryanwong.gmap2ics.app.models.timeline.placevisit.PlaceVisit
 import us.dustinj.timezonemap.TimeZone
 
-object TimelineRepositoryImplTestData {
+internal object TimelineRepositoryImplTestData {
     val mockJsonString = """{
   "timelineObjects": [{
     "activitySegment": {

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/source/googleapi/ktor/GoogleMapsApiClientImplTest.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/source/googleapi/ktor/GoogleMapsApiClientImplTest.kt
@@ -54,16 +54,7 @@ internal class GoogleMapsApiClientImplTest : FreeSpec() {
                         status = HttpStatusCode.OK,
                         payload = mockPlaceDetailsGregAve
                     )
-
-                    // 🟡 When
-                    val placeDetails = apiClient.getPlaceDetails(
-                        placeId = "some-placeId",
-                        apiKey = "some-api-key",
-                        language = "some-language"
-                    )
-
-                    // 🟢 Then
-                    placeDetails shouldBe uk.ryanwong.gmap2ics.data.models.places.PlaceDetails(
+                    val expectedPlaceDetails = uk.ryanwong.gmap2ics.data.models.places.PlaceDetails(
                         result = Result(
                             formattedAddress = "8 Greg Ave, Bollington, Macclesfield SK10 5HR, UK",
                             formattedPhoneNumber = null,
@@ -80,6 +71,16 @@ internal class GoogleMapsApiClientImplTest : FreeSpec() {
                             website = null
                         )
                     )
+
+                    // 🟡 When
+                    val placeDetails = apiClient.getPlaceDetails(
+                        placeId = "some-placeId",
+                        apiKey = "some-api-key",
+                        language = "some-language"
+                    )
+
+                    // 🟢 Then
+                    placeDetails shouldBe expectedPlaceDetails
                 }
             }
 

--- a/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/source/googleapi/ktor/KtorGoogleApiDataSourceTestData.kt
+++ b/src/jvmTest/kotlin/uk/ryanwong/gmap2ics/data/source/googleapi/ktor/KtorGoogleApiDataSourceTestData.kt
@@ -8,7 +8,7 @@ import uk.ryanwong.gmap2ics.data.models.places.Geometry
 import uk.ryanwong.gmap2ics.data.models.places.Location
 import uk.ryanwong.gmap2ics.data.models.places.Result
 
-object KtorGoogleApiDataSourceTestData {
+internal object KtorGoogleApiDataSourceTestData {
     /***
      * Data source unit tests I would prefer using real data samples.
      */


### PR DESCRIPTION
A continued effort to improve tests even without Greg now.

- factorised data objects to avoid being repeated in individual tests.
- moved expected results to the Given block as constant
- mark test data object classes as internal
- remove duplicated unit test