### PR TITLE
[chore] Migrate linting from gradleKtlint to Kotlinter

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -22,8 +22,8 @@ GMap2iCal is a Kotlin Multiplatform **Compose Desktop** application that convert
 ./gradlew allTests                 # Run all platform tests
 
 # Code quality
-./gradlew ktlintCheck              # Lint check
-./gradlew ktlintFormat             # Auto-format
+./gradlew lintKotlin               # Lint check
+./gradlew formatKotlin             # Auto-format
 ./gradlew jacocoTestReport         # Code coverage report (XML + HTML)
 
 # Distribution
@@ -81,7 +81,7 @@ Uses `Result<T>` pattern with a custom `.except()` extension for exception wrapp
 | Serialization | Kotlin Serialization |
 | MVVM | MoKo MVVM 0.16.1 |
 | Testing | JUnit 5, MockK |
-| Linting | ktlint 14.2.0 |
+| Linting | Kotlinter 5.4.2 |
 | Coverage | JaCoCo (Gradle built-in) |
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Trying to reuse all my Android development knowledge as possible, otherwise nati
 * [Github Actions](https://github.com/features/actions) - CI
 * [Kover](https://github.com/Kotlin/kotlinx-kover) - code coverage
 * [codecov](https://codecov.io/) - code coverage
-* [Ktlint Gradle](https://github.com/jlleitschuh/ktlint-gradle) - ktlint plugin to check and apply code autoformat
+* [Kotlinter](https://github.com/jeremymailen/kotlinter-gradle) - Gradle plugin to lint and format Kotlin source files
 * [Mend Renovate](https://www.mend.io/free-developer-tools/renovate/) - automatic dependency updates
 
 I use Generative AI to name all my unit test functions.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     alias(libs.plugins.multiplatform)
     alias(libs.plugins.serialization)
     alias(libs.plugins.compose)
-    alias(libs.plugins.gradle.ktlint)
+    alias(libs.plugins.kotlinter)
     alias(libs.plugins.compose.compiler)
     id("jacoco")
 }
@@ -94,12 +94,12 @@ kotlin {
     }
 }
 
-ktlint {
-    enableExperimentalRules.set(true)
-    filter {
-        // exclude("**/generated/**")
-        exclude { projectDir.toURI().relativize(it.file.toURI()).path.contains("/generated/") }
-    }
+tasks.withType<org.jmailen.gradle.kotlinter.tasks.LintTask>().configureEach {
+    exclude("**/generated/**")
+}
+
+tasks.withType<org.jmailen.gradle.kotlinter.tasks.FormatTask>().configureEach {
+    exclude("**/generated/**")
 }
 
 compose.desktop {

--- a/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/domain/models/ActivitySegmentFormatter.kt
+++ b/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/domain/models/ActivitySegmentFormatter.kt
@@ -21,6 +21,7 @@ object ActivitySegmentFormatter {
             }
 
             startLocation == null && endLocation == null -> ""
+
             else -> "($startLocation ➡ $endLocation)"
         }
     }

--- a/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/ui/viewmodels/MainScreenViewModel.kt
@@ -249,6 +249,7 @@ class MainScreenViewModel(
             }
 
             is JFileChooserResult.Cancelled -> _mainScreenUIState.value = MainScreenUIState.Ready
+
             else ->
                 _mainScreenUIState.value = MainScreenUIState.Error(errMsg = "Error updating JSON path")
         }
@@ -262,6 +263,7 @@ class MainScreenViewModel(
             }
 
             is JFileChooserResult.Cancelled -> _mainScreenUIState.value = MainScreenUIState.Ready
+
             else -> _mainScreenUIState.value = MainScreenUIState.Error(errMsg = "Error updating iCal path")
         }
     }

--- a/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/domain/models/VEventTest.kt
+++ b/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/domain/models/VEventTest.kt
@@ -19,14 +19,14 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 internal class VEventTest {
-    /**
+    /*
      * Test Plan -
      * 1. from() with happy flow - from ActivitySegment, PlaceVisit and ChildVisit
      * 2. export() with happy flow - test data need to include string replacement to make sure being substituted correctly
      * 3. getLocalizedTimeStamp() - test the fixed pattern for happy flow, and negative cases
      */
 
-    /**
+    /*
      * While for some strings we can safely replace them with "some-strings", for those we expect some special formatting,
      * like timestamp, or url, I would take a balance by making them meaningless enough but keeping the format.
      */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ coroutines = "1.10.2"
 ktor = "3.4.1"
 timezonemap = "4.5"
 napier = "2.7.1"
-gradleKtlint = "14.2.0"
+kotlinter = "5.4.2"
 compose = "1.10.3"
 mockk = "1.14.9"
 junit = "6.0.3"
@@ -43,4 +43,4 @@ multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotl
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 compose = { id = "org.jetbrains.compose", version.ref = "compose" }
-gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "gradleKtlint" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }


### PR DESCRIPTION
## Summary
- Replaces the `org.jlleitschuh.gradle.ktlint` plugin with `org.jmailen.kotlinter` (v5.4.2) in `libs.versions.toml`
- Updates `composeApp/build.gradle.kts` to apply `alias(libs.plugins.kotlinter)` and replaces the `ktlint {}` config block with `tasks.withType<LintTask>` / `tasks.withType<FormatTask>` exclusions for generated sources
- Fixes a `standard:kdoc` lint violation in `VEventTest.kt` (orphaned KDoc-style comments inside class body converted to regular block comments)
- Applies kotlinter auto-formatting to `ActivitySegmentFormatter.kt` and `MainScreenViewModel.kt` (blank lines before `else` branches)
- Updates `AGENT.md` commands (`ktlintCheck`→`lintKotlin`, `ktlintFormat`→`formatKotlin`) and technology table
- Updates `README.md` library reference from Ktlint Gradle to Kotlinter

## Test plan
- [ ] `./gradlew formatKotlin` completes with no changes
- [ ] `./gradlew lintKotlin` passes with no errors
- [ ] CI build passes on this branch

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)