### PR TITLE
[fix] Handle unknown Google place types without stack traces

### DIFF
--- a/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/domain/models/timeline/PlaceDetails.kt
+++ b/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/domain/models/timeline/PlaceDetails.kt
@@ -14,28 +14,11 @@ data class PlaceDetails(
     val types: List<String>,
     val url: String,
 ) {
-    fun getFormattedName(): String = try {
-        val placeType = resolveEnum()
-        "${placeType.emoji} $name"
-    } catch (ex: PlaceTypeNotFoundException) {
-        ex.printStackTrace()
-        "\uD83D\uDCCD $name"
-    }
-
-    private fun resolveEnum(): PlaceType {
-        for (type in types) {
-            try {
-                return PlaceType.valueOf(type.uppercase())
-            } catch (ex: IllegalArgumentException) {
-                // do nothing - look for the next one as substitute
-                ex.printStackTrace()
-            }
+    fun getFormattedName(): String {
+        val placeType = types.firstNotNullOfOrNull { type ->
+            PlaceType.entries.firstOrNull { placeType -> placeType.name.equals(type, ignoreCase = true) }
         }
-        throw PlaceTypeNotFoundException(types = types, placeId = placeId)
+        val emoji = placeType?.emoji ?: "\uD83D\uDCCD"
+        return "$emoji $name"
     }
-}
-
-class PlaceTypeNotFoundException(val types: List<String>, val placeId: String) : Exception() {
-    override val message: String
-        get() = "⚠️ Unable to resolve any of the place types in $types for PlaceId $placeId"
 }

--- a/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/domain/models/timeline/PlaceDetailsTest.kt
+++ b/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/domain/models/timeline/PlaceDetailsTest.kt
@@ -69,4 +69,23 @@ internal class PlaceDetailsTest {
         val formattedName = placeDetails.getFormattedName()
         assertEquals("\uD83D\uDCCD some-name", formattedName)
     }
+
+    @Test
+    fun `skips unknown place type and uses the first known place type`() {
+        val placeDetails = PlaceDetails(
+            placeId = "some-place-id",
+            name = "some-name",
+            formattedAddress = "some-formatted-address",
+            geo = LatLng(latitude = 53.6152405, longitude = -1.5639315),
+            types = listOf(
+                "establishment",
+                "restaurant",
+            ),
+            url = "https://maps.google.com/?cid=1021876599690425051",
+        )
+
+        val formattedName = placeDetails.getFormattedName()
+
+        assertEquals("\uD83D\uDC68\u200D\uD83C\uDF73 some-name", formattedName)
+    }
 }


### PR DESCRIPTION
## What changed

- Replace exception-driven `PlaceType` resolution with a safe lookup.
- Skip unknown Google place types and continue to the first recognized type.
- Preserve the existing pin emoji fallback when no type is recognized.
- Add a regression test for an unknown `establishment` type followed by `restaurant`.

## Why

Google Places can return generic types such as `establishment` that are not represented by the app's `PlaceType` enum. These are expected lookup misses, but the previous implementation caught `IllegalArgumentException` and printed a full stack trace for each one, making successful exports look like failures.

This removes that noisy exception-based control flow while preserving the existing event naming behavior.

Related to #340.

## Validation

- `./gradlew desktopTest lintKotlin --no-daemon`
- 166 desktop tests passed
- Kotlin lint passed
