### PR TITLE
[feature] Support on-device Timeline semantic segments

### DIFF
--- a/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/LocalDataSourceImpl.kt
+++ b/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/LocalDataSourceImpl.kt
@@ -38,6 +38,10 @@ class LocalDataSourceImpl(
         File(filePath).readText(Charsets.UTF_8)
     }
 
+    override suspend fun openInputStream(filePath: String) = withContext(dispatcher) {
+        File(filePath).inputStream().buffered()
+    }
+
     override suspend fun fileWriter(filePath: String, contents: String): Result<Unit> = withContext(dispatcher) {
         Result.runCatching {
             FileWriter(filePath, false).use { fileWriter ->

--- a/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/interfaces/LocalDataSource.kt
+++ b/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/interfaces/LocalDataSource.kt
@@ -4,8 +4,11 @@
 
 package uk.ryanwong.gmap2ics.data.datasources.local.interfaces
 
+import java.io.InputStream
+
 interface LocalDataSource {
     suspend fun getFileList(absolutePath: String, extension: String): Result<List<String>>
     suspend fun fileWriter(filePath: String, contents: String): Result<Unit>
+    suspend fun openInputStream(filePath: String): InputStream
     suspend fun readStringFromFile(filePath: String): String
 }

--- a/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/TimelineFileDto.kt
+++ b/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/TimelineFileDto.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022-2026. Ryan Wong (hello@ryanwebmail.com)
+ */
+
+package uk.ryanwong.gmap2ics.data.models.timeline
+
+import kotlinx.serialization.Serializable
+import kotlin.math.roundToInt
+
+/**
+ * Root model for both the legacy Google Takeout export and the newer on-device
+ * Timeline export.
+ */
+@Serializable
+data class TimelineFileDto(
+    val timelineObjects: List<TimelineObjectDto>? = null,
+    val semanticSegments: List<SemanticSegmentDto>? = null,
+) {
+    fun toTimelineObjectsDto(): TimelineObjectsDto = when {
+        timelineObjects != null -> TimelineObjectsDto(timelineObjects = timelineObjects)
+
+        semanticSegments != null -> TimelineObjectsDto(
+            timelineObjects = semanticSegments.mapNotNull(SemanticSegmentDto::toTimelineObjectDto),
+        )
+
+        else -> throw IllegalArgumentException(
+            "Unsupported Timeline JSON: expected 'timelineObjects' or 'semanticSegments' at the root",
+        )
+    }
+}
+
+@Serializable
+data class SemanticSegmentDto(
+    val startTime: String? = null,
+    val endTime: String? = null,
+    val visit: SemanticVisitDto? = null,
+    val activity: SemanticActivityDto? = null,
+) {
+    fun toTimelineObjectDto(): TimelineObjectDto? {
+        val startTimestamp = startTime ?: return null
+        val endTimestamp = endTime ?: return null
+
+        return when {
+            visit != null -> visit.toTimelineObjectDto(
+                startTimestamp = startTimestamp,
+                endTimestamp = endTimestamp,
+            )
+
+            activity != null -> activity.toTimelineObjectDto(
+                startTimestamp = startTimestamp,
+                endTimestamp = endTimestamp,
+            )
+
+            else -> null
+        }
+    }
+}
+
+@Serializable
+data class SemanticVisitDto(
+    val topCandidate: SemanticPlaceCandidateDto? = null,
+) {
+    fun toTimelineObjectDto(startTimestamp: String, endTimestamp: String): TimelineObjectDto? {
+        val candidate = topCandidate ?: return null
+        val coordinates = candidate.placeLocation?.toCoordinates() ?: return null
+
+        return TimelineObjectDto(
+            placeVisit = PlaceVisitDto(
+                duration = DurationDto(
+                    startTimestamp = startTimestamp,
+                    endTimestamp = endTimestamp,
+                ),
+                location = LocationDto(
+                    latitudeE7 = coordinates.latitudeE7,
+                    longitudeE7 = coordinates.longitudeE7,
+                    name = candidate.semanticType.toLocationName(),
+                    placeId = candidate.placeId,
+                ),
+            ),
+        )
+    }
+}
+
+@Serializable
+data class SemanticPlaceCandidateDto(
+    val placeId: String? = null,
+    val semanticType: String? = null,
+    val placeLocation: LatLngStringDto? = null,
+)
+
+@Serializable
+data class SemanticActivityDto(
+    val start: LatLngStringDto? = null,
+    val end: LatLngStringDto? = null,
+    val distanceMeters: Double? = null,
+    val topCandidate: SemanticActivityCandidateDto? = null,
+) {
+    fun toTimelineObjectDto(startTimestamp: String, endTimestamp: String): TimelineObjectDto? {
+        val startCoordinates = start?.toCoordinates() ?: return null
+        val endCoordinates = end?.toCoordinates() ?: return null
+        val activityType = topCandidate?.type
+
+        return TimelineObjectDto(
+            activitySegment = ActivitySegmentDto(
+                activityType = activityType,
+                activities = activityType?.let { type -> listOf(ActivityDto(activityType = type)) },
+                distance = distanceMeters?.roundToInt(),
+                duration = DurationDto(
+                    startTimestamp = startTimestamp,
+                    endTimestamp = endTimestamp,
+                ),
+                startLocation = ActivityLocationDto(
+                    latitudeE7 = startCoordinates.latitudeE7,
+                    longitudeE7 = startCoordinates.longitudeE7,
+                ),
+                endLocation = ActivityLocationDto(
+                    latitudeE7 = endCoordinates.latitudeE7,
+                    longitudeE7 = endCoordinates.longitudeE7,
+                ),
+            ),
+        )
+    }
+}
+
+@Serializable
+data class SemanticActivityCandidateDto(
+    val type: String? = null,
+)
+
+@Serializable
+data class LatLngStringDto(
+    val latLng: String? = null,
+) {
+    fun toCoordinates(): E7Coordinates? {
+        val match = latLng?.let(COORDINATE_PATTERN::matchEntire) ?: return null
+        val latitude = match.groupValues[1].toDoubleOrNull() ?: return null
+        val longitude = match.groupValues[2].toDoubleOrNull() ?: return null
+
+        if (latitude !in -90.0..90.0 || longitude !in -180.0..180.0) {
+            return null
+        }
+
+        return E7Coordinates(
+            latitudeE7 = (latitude * E7_SCALE).roundToInt(),
+            longitudeE7 = (longitude * E7_SCALE).roundToInt(),
+        )
+    }
+
+    companion object {
+        private const val E7_SCALE = 10_000_000.0
+        private val COORDINATE_PATTERN = Regex(
+            pattern = """^\s*(-?\d+(?:\.\d+)?)°?\s*,\s*(-?\d+(?:\.\d+)?)°?\s*$""",
+        )
+    }
+}
+
+data class E7Coordinates(
+    val latitudeE7: Int,
+    val longitudeE7: Int,
+)
+
+private fun String?.toLocationName(): String = when (this) {
+    "HOME", "INFERRED_HOME" -> "Home"
+    "WORK", "INFERRED_WORK" -> "Work"
+    "ALIASED_LOCATION" -> "Saved place"
+    "SEARCHED_ADDRESS" -> "Searched address"
+    else -> "Visited place"
+}

--- a/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/repositories/TimelineRepositoryImpl.kt
+++ b/composeApp/src/commonMain/kotlin/uk/ryanwong/gmap2ics/data/repositories/TimelineRepositoryImpl.kt
@@ -7,11 +7,13 @@ package uk.ryanwong.gmap2ics.data.repositories
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
 import uk.ryanwong.gmap2ics.data.datasources.local.LocalDataSourceImpl
 import uk.ryanwong.gmap2ics.data.datasources.local.interfaces.LocalDataSource
 import uk.ryanwong.gmap2ics.data.except
-import uk.ryanwong.gmap2ics.data.models.timeline.TimelineObjectsDto
+import uk.ryanwong.gmap2ics.data.models.timeline.TimelineFileDto
 import uk.ryanwong.gmap2ics.domain.models.timeline.Timeline
 import uk.ryanwong.gmap2ics.domain.repositories.TimelineRepository
 import uk.ryanwong.gmap2ics.domain.utils.timezonemap.TimeZoneMapWrapper
@@ -24,10 +26,13 @@ class TimelineRepositoryImpl(
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : TimelineRepository {
 
+    @OptIn(ExperimentalSerializationApi::class)
     override suspend fun getTimeLine(filePath: String): Result<Timeline> = withContext(dispatcher) {
         Result.runCatching {
-            val jsonString = localDataSource.readStringFromFile(filePath = filePath)
-            val timelineObjectsDto = kotlinJson.decodeFromString(TimelineObjectsDto.serializer(), jsonString)
+            val timelineFileDto = localDataSource.openInputStream(filePath = filePath).use { inputStream ->
+                kotlinJson.decodeFromStream(TimelineFileDto.serializer(), inputStream)
+            }
+            val timelineObjectsDto = timelineFileDto.toTimelineObjectsDto()
             Timeline.from(timelineObjectsDto = timelineObjectsDto, timeZoneMap = timeZoneMap)
         }.except<CancellationException, _>()
     }

--- a/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/LocalDataSourceImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/LocalDataSourceImplTest.kt
@@ -108,6 +108,17 @@ internal class LocalDataSourceImplTest {
     }
 
     @Test
+    fun `opens file contents as an input stream`() = testScope.runTest {
+        val absolutePath = tempDir.absolutePath + "/some-temp-file-5"
+
+        val actualFileContents = localDataSource.openInputStream(filePath = absolutePath).use { inputStream ->
+            inputStream.bufferedReader().readText()
+        }
+
+        assertEquals("some-file-contents", actualFileContents)
+    }
+
+    @Test
     fun `readStringFromFile should throw FileNotFoundException if the file does not exist`() = testScope.runTest {
         val absolutePath = tempDir.absolutePath + "/some-invalid-file"
 

--- a/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/fakes/FakeLocalDataSource.kt
+++ b/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/datasources/local/fakes/FakeLocalDataSource.kt
@@ -5,6 +5,7 @@
 package uk.ryanwong.gmap2ics.data.datasources.local.fakes
 
 import uk.ryanwong.gmap2ics.data.datasources.local.interfaces.LocalDataSource
+import java.io.ByteArrayInputStream
 
 internal class FakeLocalDataSource : LocalDataSource {
     var getFileListResponse: Result<List<String>>? = null
@@ -22,5 +23,8 @@ internal class FakeLocalDataSource : LocalDataSource {
     }
 
     var getJsonStringResponse: String = ""
+    override suspend fun openInputStream(filePath: String) = ByteArrayInputStream(
+        getJsonStringResponse.toByteArray(Charsets.UTF_8),
+    )
     override suspend fun readStringFromFile(filePath: String): String = getJsonStringResponse
 }

--- a/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/TimelineFileDtoTest.kt
+++ b/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/TimelineFileDtoTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2022-2026. Ryan Wong (hello@ryanwebmail.com)
+ */
+
+package uk.ryanwong.gmap2ics.data.models.timeline
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+internal class TimelineFileDtoTest {
+
+    @Test
+    fun `prefers legacy timeline objects when both schemas are present`() {
+        val legacyObject = TimelineObjectDto()
+
+        val result = TimelineFileDto(
+            timelineObjects = listOf(legacyObject),
+            semanticSegments = listOf(SemanticSegmentDto()),
+        ).toTimelineObjectsDto()
+
+        val timelineObjects = assertNotNull(result.timelineObjects)
+        assertEquals(1, timelineObjects.size)
+        assertSame(legacyObject, timelineObjects.single())
+    }
+
+    @Test
+    fun `skips incomplete and unsupported semantic segments`() {
+        assertNull(SemanticSegmentDto().toTimelineObjectDto())
+        assertNull(SemanticSegmentDto(startTime = START_TIME).toTimelineObjectDto())
+        assertNull(
+            SemanticSegmentDto(
+                startTime = START_TIME,
+                endTime = END_TIME,
+            ).toTimelineObjectDto(),
+        )
+    }
+
+    @Test
+    fun `skips visits without a candidate or usable coordinates`() {
+        assertNull(SemanticVisitDto().toTimelineObjectDto(START_TIME, END_TIME))
+        assertNull(
+            SemanticVisitDto(
+                topCandidate = SemanticPlaceCandidateDto(),
+            ).toTimelineObjectDto(START_TIME, END_TIME),
+        )
+        assertNull(
+            SemanticVisitDto(
+                topCandidate = SemanticPlaceCandidateDto(
+                    placeLocation = LatLngStringDto("not coordinates"),
+                ),
+            ).toTimelineObjectDto(START_TIME, END_TIME),
+        )
+    }
+
+    @Test
+    fun `maps semantic visit labels to location names`() {
+        val expectedNames = listOf(
+            "HOME" to "Home",
+            "INFERRED_HOME" to "Home",
+            "WORK" to "Work",
+            "INFERRED_WORK" to "Work",
+            "ALIASED_LOCATION" to "Saved place",
+            "SEARCHED_ADDRESS" to "Searched address",
+            "UNKNOWN" to "Visited place",
+            null to "Visited place",
+        )
+
+        expectedNames.forEach { (semanticType, expectedName) ->
+            val result = SemanticVisitDto(
+                topCandidate = SemanticPlaceCandidateDto(
+                    placeId = "place-id",
+                    semanticType = semanticType,
+                    placeLocation = LatLngStringDto("39.7392°, -104.9903°"),
+                ),
+            ).toTimelineObjectDto(START_TIME, END_TIME)
+
+            val location = assertNotNull(result?.placeVisit).location
+            assertEquals(expectedName, location.name)
+            assertEquals("place-id", location.placeId)
+        }
+    }
+
+    @Test
+    fun `skips activities without usable start and end coordinates`() {
+        assertNull(SemanticActivityDto().toTimelineObjectDto(START_TIME, END_TIME))
+        assertNull(
+            SemanticActivityDto(
+                start = LatLngStringDto("39.7392, -104.9903"),
+            ).toTimelineObjectDto(START_TIME, END_TIME),
+        )
+        assertNull(
+            SemanticActivityDto(
+                start = LatLngStringDto("39.7392, -104.9903"),
+                end = LatLngStringDto("invalid"),
+            ).toTimelineObjectDto(START_TIME, END_TIME),
+        )
+    }
+
+    @Test
+    fun `maps an activity when optional metadata is absent`() {
+        val result = SemanticActivityDto(
+            start = LatLngStringDto("39.7392, -104.9903"),
+            end = LatLngStringDto("39.7492, -105.0103"),
+            topCandidate = SemanticActivityCandidateDto(),
+        ).toTimelineObjectDto(START_TIME, END_TIME)
+
+        val activity = assertNotNull(result?.activitySegment)
+        assertNull(activity.activityType)
+        assertNull(activity.activities)
+        assertNull(activity.distance)
+        assertEquals(397392000, activity.startLocation.latitudeE7)
+        assertEquals(-1050103000, activity.endLocation.longitudeE7)
+    }
+
+    @Test
+    fun `parses coordinate boundaries and rejects invalid coordinate strings`() {
+        assertEquals(
+            E7Coordinates(latitudeE7 = -900000000, longitudeE7 = 1800000000),
+            LatLngStringDto("-90°, 180°").toCoordinates(),
+        )
+
+        listOf(
+            LatLngStringDto(),
+            LatLngStringDto("not coordinates"),
+            LatLngStringDto("91, 0"),
+            LatLngStringDto("0, -181"),
+        ).forEach { coordinates ->
+            assertNull(coordinates.toCoordinates())
+        }
+    }
+
+    private companion object {
+        const val START_TIME = "2026-08-10T08:30:00.000-06:00"
+        const val END_TIME = "2026-08-10T09:00:00.000-06:00"
+    }
+}

--- a/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/TimelineFileDtoTest.kt
+++ b/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/models/timeline/TimelineFileDtoTest.kt
@@ -88,12 +88,12 @@ internal class TimelineFileDtoTest {
         assertNull(SemanticActivityDto().toTimelineObjectDto(START_TIME, END_TIME))
         assertNull(
             SemanticActivityDto(
-                start = LatLngStringDto("39.7392, -104.9903"),
+                start = LatLngStringDto(START_COORDINATES),
             ).toTimelineObjectDto(START_TIME, END_TIME),
         )
         assertNull(
             SemanticActivityDto(
-                start = LatLngStringDto("39.7392, -104.9903"),
+                start = LatLngStringDto(START_COORDINATES),
                 end = LatLngStringDto("invalid"),
             ).toTimelineObjectDto(START_TIME, END_TIME),
         )
@@ -102,7 +102,7 @@ internal class TimelineFileDtoTest {
     @Test
     fun `maps an activity when optional metadata is absent`() {
         val result = SemanticActivityDto(
-            start = LatLngStringDto("39.7392, -104.9903"),
+            start = LatLngStringDto(START_COORDINATES),
             end = LatLngStringDto("39.7492, -105.0103"),
             topCandidate = SemanticActivityCandidateDto(),
         ).toTimelineObjectDto(START_TIME, END_TIME)
@@ -135,5 +135,6 @@ internal class TimelineFileDtoTest {
     private companion object {
         const val START_TIME = "2026-08-10T08:30:00.000-06:00"
         const val END_TIME = "2026-08-10T09:00:00.000-06:00"
+        const val START_COORDINATES = "39.7392, -104.9903"
     }
 }

--- a/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/repositories/TimelineRepositoryImplTest.kt
+++ b/composeApp/src/commonTest/kotlin/uk/ryanwong/gmap2ics/data/repositories/TimelineRepositoryImplTest.kt
@@ -15,6 +15,8 @@ import uk.ryanwong.gmap2ics.data.repositories.TimelineRepositoryImplTestData.tim
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -61,5 +63,81 @@ internal class TimelineRepositoryImplTest {
         // kotlinx.serialization.json.internal.JsonDecodingException is internal. Assert message only.
         assertTrue(timeLine.isFailure)
         assertEquals(expectedMessage, timeLine.exceptionOrNull()!!.message)
+    }
+
+    @Test
+    fun `converts on-device semantic segments into timeline entries`() = runTest {
+        localDataSource.getJsonStringResponse = MODERN_TIMELINE_JSON_STRING
+        fakeTimeZoneMap.zoneId = "America/Denver"
+
+        val result = timelineRepository.getTimeLine(filePath = "/some-absolute-path/Timeline.json")
+
+        assertTrue(result.isSuccess)
+        val entries = assertNotNull(result.getOrNull()).timelineEntries
+        assertEquals(2, entries.size)
+
+        val placeVisit = assertNotNull(entries[0].placeVisit)
+        assertNull(entries[0].activitySegment)
+        assertEquals("ChIJ-example", placeVisit.location.placeId)
+        assertEquals("Home", placeVisit.location.name)
+        assertEquals(39.7392, placeVisit.location.getLatitude())
+        assertEquals(-104.9903, placeVisit.location.getLongitude())
+        assertEquals("2026-08-10T08:30:00.000-06:00", placeVisit.durationStartTimestamp.timestamp)
+
+        val activitySegment = assertNotNull(entries[1].activitySegment)
+        assertNull(entries[1].placeVisit)
+        assertEquals("IN_PASSENGER_VEHICLE", activitySegment.rawActivityType)
+        assertEquals(1235, activitySegment.distance)
+        assertEquals(39.7392, activitySegment.startLocation.getLatitude())
+        assertEquals(-105.0103, activitySegment.endLocation.getLongitude())
+    }
+
+    @Test
+    fun `returns failure for valid JSON with an unsupported root schema`() = runTest {
+        localDataSource.getJsonStringResponse = """{"rawSignals": []}"""
+
+        val result = timelineRepository.getTimeLine(filePath = "/some-absolute-path/Timeline.json")
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            "Unsupported Timeline JSON: expected 'timelineObjects' or 'semanticSegments' at the root",
+            result.exceptionOrNull()?.message,
+        )
+    }
+
+    private companion object {
+        const val MODERN_TIMELINE_JSON_STRING = """
+            {
+              "semanticSegments": [
+                {
+                  "startTime": "2026-08-10T08:30:00.000-06:00",
+                  "endTime": "2026-08-10T09:00:00.000-06:00",
+                  "visit": {
+                    "topCandidate": {
+                      "placeId": "ChIJ-example",
+                      "semanticType": "HOME",
+                      "placeLocation": {"latLng": "39.7392°, -104.9903°"}
+                    }
+                  }
+                },
+                {
+                  "startTime": "2026-08-10T09:00:00.000-06:00",
+                  "endTime": "2026-08-10T09:15:00.000-06:00",
+                  "activity": {
+                    "start": {"latLng": "39.7392°, -104.9903°"},
+                    "end": {"latLng": "39.7492°, -105.0103°"},
+                    "distanceMeters": 1234.6,
+                    "topCandidate": {"type": "IN_PASSENGER_VEHICLE"}
+                  }
+                },
+                {
+                  "startTime": "2026-08-10T09:00:00.000-06:00",
+                  "endTime": "2026-08-10T10:00:00.000-06:00",
+                  "timelinePath": []
+                }
+              ],
+              "rawSignals": [{"ignored": true}]
+            }
+        """
     }
 }


### PR DESCRIPTION
## What changed

- Add support for the newer on-device Timeline JSON root schema using `semanticSegments`.
- Convert visit segments into the existing `PlaceVisitDto` pipeline.
- Convert activity segments into the existing `ActivitySegmentDto` pipeline.
- Preserve support for legacy Google Takeout files using `timelineObjects`.
- Skip path-only or incomplete semantic segments that cannot produce calendar events.
- Decode Timeline JSON from a buffered input stream instead of loading the entire file into a `String` first.
- Return a clear failure for valid JSON with an unsupported root schema.

## Why

Google has moved Timeline storage to devices, and those exports use a different JSON structure from the legacy Semantic Location History Takeout files. Large on-device exports can also be hundreds of megabytes, so streaming the decoder avoids creating an additional full-file string before deserialization.

This lets existing event-generation logic process both formats without changing its domain model.

Related to #149.

## Validation

- `./gradlew desktopTest lintKotlin --no-daemon`
- 169 desktop tests passed
- Kotlin lint passed
- Verified the expected field and coordinate formats against a 139 MB on-device Timeline export; no personal Timeline data is included in this PR
